### PR TITLE
Add complete support for HTTP-based test methods on DrupalWebTestCase 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_script:
 
   # install php packages required for running a web server from drush on php 5.3
   - sudo apt-get update > /dev/null
-  - sudo apt-get install -y --force-yes php5-cgi
+  - sudo apt-get install -y --force-yes php5-cgi php5-mysql
 
   # create new site, stubbing sendmail path with true to prevent delivery errors and manually resolving drush path
   - mysql -e 'create database travis_ci_drupal_module_example_test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,21 @@ before_script:
   - pear install drush/drush-5.8.0
   - phpenv rehash
 
+  # install php packages required for running a web server from drush on php 5.3
+  - sudo apt-get update > /dev/null
+  - sudo apt-get install -y --force-yes php5-cgi
+
   # create new site, stubbing sendmail path with true to prevent delivery errors and manually resolving drush path
   - mysql -e 'create database travis_ci_drupal_module_example_test'
   - php -d sendmail_path=`which true` `pear config-get php_dir`/drush/drush.php --yes core-quick-drupal --profile=testing --no-server --db-url=mysql://root:@127.0.0.1/travis_ci_drupal_module_example_test --enable=simpletest travis_ci_drupal_module_example_test
+
+  # start a web server on port 8080 to run in the background, wait for initialization
+  - drush runserver 127.0.0.1:8080 &
+  - sleep 4
 
   # reference and enable travis_ci_drupal_module_example in build site
   - ln -s $(readlink -e $(cd -)) travis_ci_drupal_module_example_test/drupal/sites/all/modules/travis_ci_drupal_module_example
   - cd travis_ci_drupal_module_example_test/drupal
   - drush --yes pm-enable travis_ci_drupal_module_example
 
-script: drush test-run 'Travis-CI Drupal Module Example'
+script: drush test-run 'Travis-CI Drupal Module Example' --uri=http://127.0.0.1:8080

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,13 +25,13 @@ before_script:
   - mysql -e 'create database travis_ci_drupal_module_example_test'
   - php -d sendmail_path=`which true` `pear config-get php_dir`/drush/drush.php --yes core-quick-drupal --profile=testing --no-server --db-url=mysql://root:@127.0.0.1/travis_ci_drupal_module_example_test --enable=simpletest travis_ci_drupal_module_example_test
 
-  # start a web server on port 8080 to run in the background, wait for initialization
-  - drush runserver 127.0.0.1:8080 &
-  - sleep 4
-
   # reference and enable travis_ci_drupal_module_example in build site
   - ln -s $(readlink -e $(cd -)) travis_ci_drupal_module_example_test/drupal/sites/all/modules/travis_ci_drupal_module_example
   - cd travis_ci_drupal_module_example_test/drupal
   - drush --yes pm-enable travis_ci_drupal_module_example
+
+  # start a web server on port 8080, run in the background; wait for initialization
+  - drush runserver 127.0.0.1:8080 &
+  - sleep 4
 
 script: drush test-run 'Travis-CI Drupal Module Example' --uri=http://127.0.0.1:8080

--- a/test/drupal_web_test_case_example.test
+++ b/test/drupal_web_test_case_example.test
@@ -10,4 +10,8 @@ class TravisDrupalModuleExampleDrupalWebTestCase extends DrupalWebTestCase {
   public function testAssertTrue() {
     $this->assert(true);
   }
+
+  public function testDrupalGet() {
+    $this->drupalGet('node');
+  }
 }


### PR DESCRIPTION
I think very few people use the unit test components of SimpleTest in the Drupal ecosystem.  Seems like the Travis config should also, at a minimum, spin up a server so that methods like DrupalWebTestCase::drupalGet() and  DrupalWebTestCase::drupalPost() are functional.

Drush provides this capability (but it requires an extra PHP package to do so in PHP 5.3).  We also need PDO MySQL, since we're working with a MySQL database.

Naturally, others may want to install Apache with all requirements, or nginx, or try against sqllite / postgres, but this provides a good outline of the bare minimum.
