### PR TITLE
regrouped commands in build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,18 +8,21 @@ mysql:
   username: root
   encoding: utf8
 
-before_script:
-  # navigate out of module directory to prevent blown stack by recursive module lookup
-  - cd ../..
+before_install:
+  - sudo apt-get update > /dev/null
+
+install:
+  # install php packages required for running a web server from drush on php 5.3
+  - sudo apt-get install -y --force-yes php5-cgi php5-mysql
 
   # install drush
   - pear channel-discover pear.drush.org
   - pear install drush/drush-5.8.0
   - phpenv rehash
 
-  # install php packages required for running a web server from drush on php 5.3
-  - sudo apt-get update > /dev/null
-  - sudo apt-get install -y --force-yes php5-cgi php5-mysql
+before_script:
+  # navigate out of module directory to prevent blown stack by recursive module lookup
+  - cd ../..
 
   # create new site, stubbing sendmail path with true to prevent delivery errors and manually resolving drush path
   - mysql -e 'create database travis_ci_drupal_module_example_test'


### PR DESCRIPTION
This takes better advantage of the various stages in the [build lifecycle](http://about.travis-ci.org/docs/user/build-configuration/#Build-Lifecycle):
- moved the update package list command into the `before_installation` section
- moved the commands for installing PHP extensions and Drush into the `install` section

Please review and merge if deemed OK/worthwhile.

Thanks!
