### PR TITLE
Install http server for work command "drush runserver".

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,10 @@ install:
   - composer global require drush/drush:6.*
 
 before_script:
+  # install http server for work command "drush runserver".
+  - git clone git://github.com/youngj/httpserver.git
+  - mv httpserver /home/travis/.composer/vendor/drush/drush/lib
+
   # navigate out of module directory to prevent blown stack by recursive module lookup
   - cd ../..
 


### PR DESCRIPTION
Hi

Now, for work command "drush runserver" need install httpserver from separate repository. Without install httpserver, you will see an error:

```
The runserver command needs a copy of the httpserver library in order[error]
to function, and the attempt to download this file automatically
failed. To continue you will need to download the package from
https://github.com/youngj/httpserver/tarball/41dd2b7160b8cbd25d7b5383e3ffc6d8a9a59478,
extract it into the /home/travis/.composer/vendor/drush/drush/lib
directory, such that httpserver.php exists at
/home/travis/.composer/vendor/drush/drush/lib/youngj-httpserver-41dd2b7/httpserver.php.
```
