### PR TITLE
switch to container based, update to drush 7 and update code due to removed test-run.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,4 +49,7 @@ before_script:
   # start a web server on port 8080, run in the background; wait for initialization
   - drush runserver 127.0.0.1:8080 > ~/php-server.log 2>&1 &
 
-script: php scripts/run-tests.sh --php $(which php) --concurrency 4 --verbose --color --url 127.0.0.1:8080 'Travis-CI Drupal Module Example' 2>&1 | tee /tmp/simpletest-result.txt
+script:
+  - php scripts/run-tests.sh --php $(which php) --concurrency 4 --verbose --color --url 127.0.0.1:8080 'Travis-CI Drupal Module Example' 2>&1 | tee /tmp/simpletest-result.txt
+  - egrep -i "([1-9]+ fail)|(Fatal error)|([1-9]+ exception)" /tmp/simpletest-result.txt && exit 1
+  - exit 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,6 @@ before_script:
   - drush --yes pm-enable travis_ci_drupal_module_example
 
   # start a web server on port 8080, run in the background; wait for initialization
-  - drush runserver 127.0.0.1:8080 &
-  - until netstat -an 2>/dev/null | grep '8080.*LISTEN'; do true; done
+  - drush runserver 127.0.0.1:8080 > ~/php-server.log 2>&1 &
 
 script: php scripts/run-tests.sh --php $(which php) --concurrency 4 --verbose --color --url 127.0.0.1:8080 'Travis-CI Drupal Module Example' 2>&1 | tee /tmp/simpletest-result.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,6 @@ addons:
     - php5-cgi
     - php5-mysql
 
-before_install:
-  - sudo apt-get update > /dev/null
-
 install:
 
   # add composer's global bin directory to the path

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+sudo: false
 
 php:
   - 5.3
@@ -17,19 +18,23 @@ mysql:
   username: root
   encoding: utf8
 
+addons:
+  apt:
+    packages:
+    - php5-cgi
+    - php5-mysql
+
 before_install:
   - sudo apt-get update > /dev/null
 
 install:
-  # install php packages required for running a web server from drush on php 5.3
-  - sudo apt-get install -y --force-yes php5-cgi php5-mysql
 
   # add composer's global bin directory to the path
   # see: https://github.com/drush-ops/drush#install---composer
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
 
   # install drush globally
-  - composer global require drush/drush:6.*
+  - composer global require drush/drush:7.0
 
 before_script:
   # navigate out of module directory to prevent blown stack by recursive module lookup
@@ -48,4 +53,4 @@ before_script:
   - drush runserver 127.0.0.1:8080 &
   - until netstat -an 2>/dev/null | grep '8080.*LISTEN'; do true; done
 
-script: drush test-run 'Travis-CI Drupal Module Example' --uri=http://127.0.0.1:8080
+script: php scripts/run-tests.sh --php $(which php) --concurrency 4 --verbose --color --url 127.0.0.1:8080 'Travis-CI Drupal Module Example' 2>&1 | tee /tmp/simpletest-result.txt


### PR DESCRIPTION
Today was a bad weak for the Drupal comminity which relies on travis ci. drush 6 was not reachable and project wasn't gone through their QA.

I took the time and updated my travis file, based on this one, to container based(which is much more faster), updated to drush 7 and since test-run was deprecated I updated that as well.

Hope this will go OK. 
